### PR TITLE
fix documentation api

### DIFF
--- a/src/main/java/commonapis/DocumentationAPI.java
+++ b/src/main/java/commonapis/DocumentationAPI.java
@@ -76,6 +76,12 @@ public class DocumentationAPI extends AbstractAPI<org.epos.eposdatamodel.Documen
         }
 
         Element edmobj = elementList.get(0);
+
+        // Add type validation - only process DOCUMENTATION type Elements
+        if (!"DOCUMENTATION".equals(edmobj.getType())) {
+            return null; // Skip non-DOCUMENTATION Elements
+        }
+
         org.epos.eposdatamodel.Documentation o = new org.epos.eposdatamodel.Documentation();
 
         o.setInstanceId(edmobj.getInstanceId());


### PR DESCRIPTION
The DOCUMENTATION entity retrieval was failing with `JsonSyntaxException: Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive` during JSON parsing of database values.
